### PR TITLE
chore: refactor ServiceAccessToken constant to use own type

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Go SDK for email sender functionality in AccelByte services.
 ### Install
 
 ```
-go get -u github.com/AccelByte/eventstream-go-sdk
+go get -u github.com/AccelByte/justice-go-common-email
 ```
 
 ### Importing

--- a/constant/constant.go
+++ b/constant/constant.go
@@ -18,13 +18,15 @@ package constant
 
 import "errors"
 
+type ContextKey string
+
 const (
 	CopyrightYearTemplateKey = "CopyrightYear"
 	LanguageTagTemplateKey   = "LanguageTag"
 
 	DefaultHTTPTimeoutInSeconds = 10
 
-	ServiceAccessToken = "ServiceAccessToken"
+	ServiceAccessToken ContextKey = "ServiceAccessToken"
 )
 
 var ErrNotFound = errors.New("not found")


### PR DESCRIPTION
https://pkg.go.dev/context#WithValue

> The provided key must be comparable and should not be of type string or any other built-in type to avoid collisions between packages using context. Users of WithValue should define their own types for keys. To avoid allocating when assigning to an interface{}, context keys often have concrete type struct{}